### PR TITLE
Add daily schedule view

### DIFF
--- a/frontend/css/daily.css
+++ b/frontend/css/daily.css
@@ -1,0 +1,57 @@
+body {
+  font-family: sans-serif;
+  margin: 0;
+  padding: 1rem;
+  background: #f4f6f8;
+}
+
+main {
+  max-width: 600px;
+  margin: auto;
+}
+
+h1 {
+  text-align: center;
+  color: #0d6efd;
+  margin-bottom: 1rem;
+}
+
+.day-nav {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.day-nav button,
+.day-nav select {
+  font-size: 1.1rem;
+  padding: 0.25rem 0.5rem;
+}
+
+.activities-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.activity-card {
+  font-size: 1.1rem;
+}
+
+.activity-hour {
+  font-size: 1rem;
+}
+
+@media (max-width: 600px) {
+  .activity-card {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+
+  .activity-hour {
+    align-self: flex-end;
+  }
+}

--- a/frontend/css/weekly.css
+++ b/frontend/css/weekly.css
@@ -1,0 +1,56 @@
+body {
+  font-family: sans-serif;
+  margin: 0;
+  padding: 1rem;
+  background: #f4f6f8;
+}
+main {
+  max-width: 1000px;
+  margin: auto;
+}
+h1 {
+  text-align: center;
+  color: #0d6efd;
+  margin-bottom: 1rem;
+}
+.week {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 4px;
+  overflow-x: auto;
+}
+.day-column {
+  background: #fff;
+  border: 1px solid #dee2e6;
+  border-radius: 6px;
+  display: flex;
+  flex-direction: column;
+  min-width: 140px;
+}
+.day-header {
+  background: #0d6efd;
+  color: #fff;
+  text-align: center;
+  padding: 0.5rem;
+  font-weight: bold;
+}
+.timeslot {
+  border-top: 1px solid #dee2e6;
+  min-height: 60px;
+  padding: 0.25rem;
+  font-size: 0.85rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.timeslot.empty {
+  background: #f8f9fa;
+}
+.timeslot span {
+  display: block;
+}
+@media (max-width: 768px) {
+  .week {
+    grid-template-columns: repeat(7, minmax(140px, 1fr));
+  }
+}

--- a/frontend/daily.html
+++ b/frontend/daily.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Vista diaria</title>
+  <link rel="stylesheet" href="css/activity-card.css">
+  <link rel="stylesheet" href="css/daily.css">
+</head>
+<body>
+  <main>
+    <h1>Agenda diaria</h1>
+    <div class="day-nav">
+      <button id="prevDay" aria-label="Día anterior">◀</button>
+      <select id="daySelect" aria-label="Seleccionar día"></select>
+      <button id="nextDay" aria-label="Día siguiente">▶</button>
+    </div>
+    <div id="dayContainer" class="activities-list"></div>
+  </main>
+
+  <script src="js/daily.js"></script>
+  <script>
+    const actividades = [
+      {"Dia": "Lunes 1", "Hora": "09:00", "Activitat": "Yoga", "Espai": "Sala 1", "Organitza": "Centro Cívico"},
+      {"Dia": "Lunes 1", "Hora": "11:00", "Activitat": "Pintura", "Espai": "Sala 2", "Organitza": "Asociación Vecinal"},
+      {"Dia": "Martes 2", "Hora": "10:00", "Activitat": "Taichí", "Espai": "Sala 1", "Organitza": "Club Esportiu"},
+      {"Dia": "Miércoles 3", "Hora": "17:00", "Activitat": "Teatro", "Espai": "Sala 3", "Organitza": "Grupo Local"}
+    ];
+
+    const dias = [...new Set(actividades.map(a => a.Dia))];
+    const select = document.getElementById('daySelect');
+    dias.forEach(d => {
+      const opt = document.createElement('option');
+      opt.value = d;
+      opt.textContent = d;
+      select.appendChild(opt);
+    });
+
+    let indice = 0;
+
+    function actualizar() {
+      const dia = dias[indice];
+      pintarVistaDiaria(actividades, dia);
+      select.value = dia;
+    }
+
+    select.addEventListener('change', () => {
+      indice = dias.indexOf(select.value);
+      actualizar();
+    });
+
+    document.getElementById('prevDay').addEventListener('click', () => {
+      indice = (indice - 1 + dias.length) % dias.length;
+      actualizar();
+    });
+
+    document.getElementById('nextDay').addEventListener('click', () => {
+      indice = (indice + 1) % dias.length;
+      actualizar();
+    });
+
+    actualizar();
+  </script>
+</body>
+</html>

--- a/frontend/js/daily.js
+++ b/frontend/js/daily.js
@@ -1,0 +1,44 @@
+function pintarVistaDiaria(actividades, dia) {
+  const contenedor = document.getElementById('dayContainer');
+  if (!contenedor) return;
+
+  const filtradas = actividades
+    .filter(a => a.Dia.toLowerCase().includes(dia.toLowerCase()))
+    .sort((a, b) => a.Hora.localeCompare(b.Hora));
+
+  contenedor.innerHTML = '';
+
+  if (!filtradas.length) {
+    const mensaje = document.createElement('p');
+    mensaje.textContent = 'No hay actividades para este día.';
+    contenedor.appendChild(mensaje);
+    return;
+  }
+
+  filtradas.forEach(act => {
+    const card = document.createElement('div');
+    card.className = 'activity-card';
+
+    const left = document.createElement('div');
+    left.className = 'activity-left';
+
+    const nombre = document.createElement('div');
+    nombre.className = 'activity-name';
+    nombre.textContent = act.Activitat;
+
+    const espacio = document.createElement('div');
+    espacio.className = 'activity-space';
+    espacio.textContent = `${act.Espai} · ${act.Organitza}`;
+
+    left.appendChild(nombre);
+    left.appendChild(espacio);
+
+    const hora = document.createElement('div');
+    hora.className = 'activity-hour';
+    hora.textContent = act.Hora;
+
+    card.appendChild(left);
+    card.appendChild(hora);
+    contenedor.appendChild(card);
+  });
+}

--- a/frontend/js/weekly.js
+++ b/frontend/js/weekly.js
@@ -1,0 +1,35 @@
+function pintarSemana(data) {
+  const dias = ['Lunes', 'Martes', 'Miércoles', 'Jueves', 'Viernes', 'Sábado', 'Domingo'];
+  const horas = ['08:00','09:00','10:00','11:00','12:00','13:00','14:00','16:30','17:30','18:30','19:30','20:30','21:30'];
+  const contenedor = document.getElementById('weekContainer');
+  contenedor.innerHTML = '';
+
+  dias.forEach(dia => {
+    const columna = document.createElement('div');
+    columna.className = 'day-column';
+
+    const cabecera = document.createElement('div');
+    cabecera.className = 'day-header';
+    cabecera.textContent = dia;
+    columna.appendChild(cabecera);
+
+    horas.forEach(hora => {
+      const bloque = document.createElement('div');
+      bloque.className = 'timeslot';
+
+      const actividad = data.find(a => a.Dia.toLowerCase().includes(dia.toLowerCase()) && a.Hora === hora);
+      if (actividad) {
+        bloque.innerHTML = `<span><strong>${actividad.Hora}</strong></span>` +
+          `<span>${actividad.Activitat}</span>` +
+          `<span>${actividad.Espai}</span>` +
+          `<span>${actividad.Organitza}</span>`;
+      } else {
+        bloque.classList.add('empty');
+      }
+
+      columna.appendChild(bloque);
+    });
+
+    contenedor.appendChild(columna);
+  });
+}

--- a/frontend/weekly.html
+++ b/frontend/weekly.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Vista semanal</title>
+  <link rel="stylesheet" href="css/weekly.css">
+</head>
+<body>
+  <main>
+    <h1>Agenda semanal</h1>
+    <div id="weekContainer" class="week"></div>
+  </main>
+  <script src="js/weekly.js"></script>
+  <script>
+    const actividades = [
+      {"Dia": "Lunes 1", "Hora": "10:00", "Activitat": "Ioga", "Espai": "Sala 1", "Organitza": "Centre Cívic"},
+      {"Dia": "Martes 2", "Hora": "11:00", "Activitat": "Pintura", "Espai": "Sala 2", "Organitza": "Associació Veïnal"},
+      {"Dia": "Jueves 4", "Hora": "18:30", "Activitat": "Teatre", "Espai": "Sala 1", "Organitza": "Grup Local"}
+    ];
+    pintarSemana(actividades);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create responsive CSS for daily view
- add JavaScript `pintarVistaDiaria` to render activities of a selected day
- provide new `daily.html` page with day navigation

## Testing
- `npm install`
- `npm start`


------
https://chatgpt.com/codex/tasks/task_e_68400320fef4832e81b959d177980aa1