### PR TITLE
Update daily and weekly views

### DIFF
--- a/frontend/daily.html
+++ b/frontend/daily.html
@@ -18,48 +18,9 @@
     <div id="dayContainer" class="activities-list"></div>
   </main>
 
+  <script src="js/cargarDatos.js"></script>
+  <script src="js/gestionarFechas.js"></script>
   <script src="js/daily.js"></script>
-  <script>
-    const actividades = [
-      {"Dia": "Lunes 1", "Hora": "09:00", "Activitat": "Yoga", "Espai": "Sala 1", "Organitza": "Centro Cívico"},
-      {"Dia": "Lunes 1", "Hora": "11:00", "Activitat": "Pintura", "Espai": "Sala 2", "Organitza": "Asociación Vecinal"},
-      {"Dia": "Martes 2", "Hora": "10:00", "Activitat": "Taichí", "Espai": "Sala 1", "Organitza": "Club Esportiu"},
-      {"Dia": "Miércoles 3", "Hora": "17:00", "Activitat": "Teatro", "Espai": "Sala 3", "Organitza": "Grupo Local"}
-    ];
-
-    const dias = [...new Set(actividades.map(a => a.Dia))];
-    const select = document.getElementById('daySelect');
-    dias.forEach(d => {
-      const opt = document.createElement('option');
-      opt.value = d;
-      opt.textContent = d;
-      select.appendChild(opt);
-    });
-
-    let indice = 0;
-
-    function actualizar() {
-      const dia = dias[indice];
-      pintarVistaDiaria(actividades, dia);
-      select.value = dia;
-    }
-
-    select.addEventListener('change', () => {
-      indice = dias.indexOf(select.value);
-      actualizar();
-    });
-
-    document.getElementById('prevDay').addEventListener('click', () => {
-      indice = (indice - 1 + dias.length) % dias.length;
-      actualizar();
-    });
-
-    document.getElementById('nextDay').addEventListener('click', () => {
-      indice = (indice + 1) % dias.length;
-      actualizar();
-    });
-
-    actualizar();
-  </script>
+  <script type="module" src="js/daily-app.js"></script>
 </body>
 </html>

--- a/frontend/js/daily-app.js
+++ b/frontend/js/daily-app.js
@@ -1,0 +1,35 @@
+document.addEventListener('DOMContentLoaded', async () => {
+  const mesActual = obtenerMesActual();
+  try {
+    const actividades = await fetchData(mesActual);
+    const dias = [...new Set(actividades.map(a => a.Dia))];
+    const select = document.getElementById('daySelect');
+    dias.forEach(d => {
+      const opt = document.createElement('option');
+      opt.value = d;
+      opt.textContent = d;
+      select.appendChild(opt);
+    });
+    let indice = 0;
+    function actualizar() {
+      const dia = dias[indice];
+      pintarVistaDiaria(actividades, dia);
+      select.value = dia;
+    }
+    select.addEventListener('change', () => {
+      indice = dias.indexOf(select.value);
+      actualizar();
+    });
+    document.getElementById('prevDay').addEventListener('click', () => {
+      indice = (indice - 1 + dias.length) % dias.length;
+      actualizar();
+    });
+    document.getElementById('nextDay').addEventListener('click', () => {
+      indice = (indice + 1) % dias.length;
+      actualizar();
+    });
+    actualizar();
+  } catch (err) {
+    console.error('❌ Error carregant activitats:', err);
+  }
+});

--- a/frontend/js/weekly-app.js
+++ b/frontend/js/weekly-app.js
@@ -1,0 +1,9 @@
+document.addEventListener('DOMContentLoaded', async () => {
+  const mesActual = obtenerMesActual();
+  try {
+    const actividades = await fetchData(mesActual);
+    pintarSemana(actividades);
+  } catch (err) {
+    console.error('❌ Error carregant activitats:', err);
+  }
+});

--- a/frontend/weekly.html
+++ b/frontend/weekly.html
@@ -11,14 +11,9 @@
     <h1>Agenda semanal</h1>
     <div id="weekContainer" class="week"></div>
   </main>
+  <script src="js/cargarDatos.js"></script>
+  <script src="js/gestionarFechas.js"></script>
   <script src="js/weekly.js"></script>
-  <script>
-    const actividades = [
-      {"Dia": "Lunes 1", "Hora": "10:00", "Activitat": "Ioga", "Espai": "Sala 1", "Organitza": "Centre Cívic"},
-      {"Dia": "Martes 2", "Hora": "11:00", "Activitat": "Pintura", "Espai": "Sala 2", "Organitza": "Associació Veïnal"},
-      {"Dia": "Jueves 4", "Hora": "18:30", "Activitat": "Teatre", "Espai": "Sala 1", "Organitza": "Grup Local"}
-    ];
-    pintarSemana(actividades);
-  </script>
+  <script type="module" src="js/weekly-app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- use the same backend modules on the daily and weekly pages
- load activities dynamically with new helper scripts

## Testing
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68493b0d2f64832ea445929719e349db